### PR TITLE
Self-hosted CLA check with updated agreement text

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,35 @@
+# CLA signing check (CLA Assistant Lite). The agreement text is CLA.md at the
+# repo root; signatures are committed to signatures/version1/cla.json on the
+# cla-signatures branch of this repo. Contributors sign by commenting
+# "I have read the CLA Document and I hereby sign the CLA" on their PR;
+# "recheck" re-runs the check. Bot-authored commits (e.g. the prebuilt-lib
+# sync jobs) are exempt via the allowlist.
+
+name: CLA
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: signatures/version1/cla.json
+          path-to-document: https://github.com/xdevplatform/chat-xdk/blob/main/CLA.md
+          branch: cla-signatures
+          allowlist: '*[bot]'

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,114 @@
+# Contributor License Agreement
+
+Thank you for your contribution to this X software project. In order to
+clarify the intellectual property rights in the project, and to grant
+licenses to the project to others, X Corp. ("X") requires that you accept
+this Contributor License Agreement ("Agreement"). This license is for your
+protection as a Contributor as well as the protection of X, its users, and
+its licensees; you may still license your own Contributions under other
+terms.
+
+You accept and agree to the following terms and conditions for Your
+Contributions submitted to X. Except for the license granted herein to X and
+recipients of software distributed by X, You reserve all right, title, and
+interest in and to Your Contributions. (If, however, you are a current or
+former employee of X, your rights and/or Contributions may be governed by
+another agreement, including your Employee Invention Assignment, and nothing
+in this Agreement shall be construed as modifying the terms of any other such
+agreement.)
+
+## 1. Definitions
+
+"You" (or "Your") shall mean the copyright owner or legal entity authorized
+by the copyright owner that is making this Agreement with X. For legal
+entities, the entity making a Contribution and all other entities that
+control, are controlled by, or are under common control with that entity are
+considered to be a single Contributor. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the direction or
+management of such entity, whether by contract or otherwise, or (ii)
+ownership of fifty percent (50%) or more of the outstanding shares, or (iii)
+beneficial ownership of such entity.
+
+"Contribution" shall mean any original work of authorship or invention,
+including any modifications or additions to an existing work, that is
+intentionally submitted by You to X for inclusion in, or documentation of,
+any of the products owned or managed by X (the "Work"). For the purposes of
+this definition, "submitted" means any form of electronic, verbal, or written
+communication sent to X or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, X for the
+purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by You as
+"Not a Contribution."
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to X
+and to recipients of software distributed by X a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare derivative works of, publicly display, publicly perform,
+and distribute Your Contributions and such derivative works, as well as the
+right to sublicense and have sublicensed all of the foregoing rights, through
+multiple tiers of sublicensees.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to X
+and to recipients of software distributed by X a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this
+section) patent license to make, have made, use, offer to sell, sell, import,
+and otherwise transfer the Work, where such license applies only to those
+patent claims licensable by You that are necessarily infringed by Your
+Contribution(s) alone or by combination of Your Contribution(s) with the Work
+to which such Contribution(s) was submitted. If any entity institutes patent
+litigation against You or any other entity (including a cross-claim or
+counterclaim in a lawsuit) alleging that your Contribution, or the Work to
+which you have contributed, constitutes direct or contributory patent
+infringement, then any patent licenses granted to that entity under this
+Agreement for that Contribution or Work shall terminate as of the date such
+litigation is filed.
+
+## 4. Authority
+
+You represent that you are legally entitled to grant the above license. If
+your employer(s) has rights to intellectual property that you create that
+includes your Contributions, you represent that you have received permission
+to make Contributions on behalf of that employer, that your employer has
+waived such rights for your contributions to X, or that your employer has
+executed with X a separate contributor license agreement substantially
+similar to this Agreement.
+
+## 5. Original Creation
+
+You represent that each of Your Contributions is Your original creation (see
+section 7 for submissions on behalf of others). You represent that Your
+Contribution submissions include complete details of any third-party license
+or other restriction (including, but not limited to, related patents and
+trademarks) of which you are personally aware and which are associated with
+any part of Your Contributions.
+
+## 6. Support and Warranty Disclaimer
+
+You are not expected to provide support for Your Contributions, except to
+the extent You desire to provide support. You may provide support for free,
+for a fee, or not at all. Unless required by applicable law or agreed to in
+writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including,
+without limitation, any warranties or conditions of title, non-infringement,
+merchantability, or fitness for a particular purpose.
+
+## 7. Third-Party Works
+
+Should You wish to submit work that is not Your original creation, You may
+submit it to X separately from any Contribution, identifying the complete
+details of its source and of any license or other restriction (including,
+but not limited to, related patents, trademarks, and license agreements) of
+which you are personally aware, and conspicuously marking the work as "Not a
+Contribution. Third-party materials licensed pursuant to: [license name(s)
+here]" (substituting the bracketed text with the appropriate license
+name(s)).
+
+## 8. Notification
+
+You agree to notify X of any facts or circumstances of which you become
+aware that would make these representations inaccurate in any respect.


### PR DESCRIPTION
## What

Moves the CLA check in-repo using [CLA Assistant Lite](https://github.com/contributor-assistant/github-action):

- **`CLA.md`** — the agreement text, now version-controlled and reviewable like any other file. The contracting entity is updated from Twitter, Inc. to X Corp.; the substance of the agreement is otherwise unchanged.
- **`.github/workflows/cla.yml`** — checks every PR for signatures. Contributors sign once by commenting `I have read the CLA Document and I hereby sign the CLA` on their PR; `recheck` re-runs the check.
- **`cla-signatures` branch** — dedicated orphan branch storing `signatures/version1/cla.json`, written by the workflow via the default `GITHUB_TOKEN` (no PAT or external service account needed).

## Why

The previous check ran through the hosted cla-assistant.io service, backed by a gist with outdated entity references that isn't editable from this repo. It also required signatures from bot committers — the automated prebuilt-lib sync commits can never sign, which left PRs stuck on a permanently failing check.

With this change the agreement, the check, and the signature record all live in the repo, and the workflow allowlists `*[bot]` so automated commits are exempt.

## Notes

- The workflow only activates once this lands on `main` (it uses `pull_request_target`).
- The old cla-assistant.io status (`license/cla`) is not a required check, so it doesn't block merges; unlinking the repo from cla-assistant.io (a dashboard action) will stop its comments on future PRs.
- Signatures from the hosted service don't carry over — contributors sign the new agreement once on their next PR.
- The entity-name update should get a quick confirmation from whoever handles legal for the developer platform.
