### PR TITLE
Sync Cargo.lock with the v0.4.1 workspace version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "chat-xdk-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "chat-xdk-dotnet"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64 0.22.1",
  "chat-xdk-core",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "chat-xdk-go"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64 0.22.1",
  "cbindgen",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "chat-xdk-macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "chat-xdk-python"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64 0.22.1",
  "chat-xdk-core",
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "chat-xdk-wasm"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64 0.22.1",
  "chat-xdk-core",


### PR DESCRIPTION
The v0.4.1 release bumped the workspace manifests without regenerating the lockfile, which leaves `Cargo.lock` recording the six workspace crates at 0.4.0. Nothing in CI breaks (no job builds with `--locked`), but every fresh `cargo build` silently rewrites the lockfile — dirtying contributors' working trees — and any `--locked`/`--frozen` build fails on the manifest/lock mismatch.

This is `cargo update --workspace` output only: the six workspace members move 0.4.0 → 0.4.1 and no dependency versions change. Verified with `cargo check --locked`.