### PR TITLE
Stamp Cargo.lock together with the manifests on release

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 CARGO_TOML="$ROOT_DIR/Cargo.toml"
+CARGO_LOCK="$ROOT_DIR/Cargo.lock"
 PYPROJECT="$ROOT_DIR/crates/pyo3/pyproject.toml"
 NPM_PKG="$ROOT_DIR/crates/wasm/js/package.json"
 POM="$ROOT_DIR/crates/jvm/java/chatxdk/pom.xml"
@@ -66,6 +67,12 @@ set_version() {
   # chat-xdk-macros workspace-dependency version (required by cargo publish for
   # path dependencies; must track the workspace version).
   perl -pi -e "s/^(chat-xdk-macros\\s*=.*version\\s*=\\s*\")[^\"]*(\")/\${1}$v\${2}/" "$CARGO_TOML"
+  # Lockfile entries for the workspace members (every chat-xdk-* package pins
+  # the workspace version). Stamped textually rather than via `cargo update`
+  # so the script works without a toolchain or the juicebox-sdk sibling
+  # checkout; without this, the stamped Cargo.toml and the committed
+  # Cargo.lock disagree and `--locked` builds of the release tag fail.
+  perl -0pi -e "s/(name = \"chat-xdk[^\"]*\"\\nversion = \")[^\"]*(\")/\${1}$v\${2}/g" "$CARGO_LOCK"
   # PyPI project version.
   perl -pi -e "s/^version\\s*=\\s*\"[^\"]*\"/version = \"$v\"/ if !\$done && /^version\\s*=/; \$done=1 if /^version\\s*=/" "$PYPROJECT"
   # npm package version (first "version" key).
@@ -81,6 +88,7 @@ set_version() {
 
 print_all() {
   echo "canonical (Cargo.toml):  $(get_current_version)"
+  echo "lockfile (Cargo.lock):   $(perl -0ne 'print $1 if /name = "chat-xdk-core"\nversion = "([^"]+)"/' "$CARGO_LOCK")"
   echo "macros dep (Cargo.toml): $(perl -ne 'print $1 if /^chat-xdk-macros\s*=.*version\s*=\s*"([^"]+)"/' "$CARGO_TOML")"
   echo "python (pyproject):      $(perl -ne 'print $1 if /^version\s*=\s*"([^"]+)"/' "$PYPROJECT")"
   echo "npm (package.json):      $(perl -0ne 'print $1 if /"version":\s*"([^"]+)"/' "$NPM_PKG")"

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -72,7 +72,18 @@ set_version() {
   # so the script works without a toolchain or the juicebox-sdk sibling
   # checkout; without this, the stamped Cargo.toml and the committed
   # Cargo.lock disagree and `--locked` builds of the release tag fail.
-  perl -0pi -e "s/(name = \"chat-xdk[^\"]*\"\\nversion = \")[^\"]*(\")/\${1}$v\${2}/g" "$CARGO_LOCK"
+  # Workspace members carry no `source` line in the lock; the lookahead skips
+  # any registry crate that happens to share the name prefix (these crates are
+  # also published to crates.io), whose pinned version must not be touched.
+  perl -0pi -e "s/(name = \"chat-xdk[^\"]*\"\\nversion = \")[^\"]*(\")(?!\\nsource)/\${1}$v\${2}/g" "$CARGO_LOCK"
+  # A silent stamp miss (e.g. a lockfile format change) would quietly
+  # reintroduce the manifest/lockfile mismatch, so verify the result.
+  local lock_v
+  lock_v="$(perl -0ne 'print $1 if /name = "chat-xdk-core"\nversion = "([^"]+)"/' "$CARGO_LOCK")"
+  if [[ "$lock_v" != "$v" ]]; then
+    echo "error: Cargo.lock stamp failed (chat-xdk-core at '${lock_v:-missing}', expected '$v')" >&2
+    exit 1
+  fi
   # PyPI project version.
   perl -pi -e "s/^version\\s*=\\s*\"[^\"]*\"/version = \"$v\"/ if !\$done && /^version\\s*=/; \$done=1 if /^version\\s*=/" "$PYPROJECT"
   # npm package version (first "version" key).


### PR DESCRIPTION
## What

`scripts/version.sh set` stamps every binding manifest but skips `Cargo.lock`, so each release commit ships a lockfile still pinned to the previous version — the v0.4.1 release commit recorded the six workspace crates at 0.4.0 (data since synced in #3). Consequences of the mismatch: every contributor's first `cargo build` silently rewrites the lockfile (dirty working tree), and any `--locked`/`--frozen` build of a release tag fails.

This PR fixes the cause:

- `version.sh set`/`bump` now stamp the `chat-xdk-*` entries in `Cargo.lock` alongside the manifests
- the stamp only touches entries **without a `source` line** (workspace members), so a registry crate that happened to share the name prefix — these crates are also published to crates.io — keeps its own pinned version
- the script **fails loudly** if the stamp matches nothing (e.g. a lockfile format change), instead of silently reintroducing the mismatch
- `version.sh list` prints the lockfile version so drift is visible at a glance

## Why textual stamping instead of `cargo update --workspace`

The release workflow's `tag` job (where the stamp runs before `git add -A`) has neither a Rust toolchain nor the `juicebox-sdk` sibling checkout that the workspace's path dependency requires, so invoking cargo there would fail. For workspace (path) packages a lock entry is only `name`/`version`/`dependencies` — no source or checksum, and dependency lists don't repeat versions — so the textual edit is byte-identical to cargo's own output. Cargo also re-validates the lock on every build, so a bad stamp can only fail loudly, never ship silently.

## Testing

- Round-trip: `version.sh set 9.9.9` updates all six lockfile entries; `set 0.4.1` restores them, leaving a clean tree.
- Registry-entry guard: an entry with a `source` line and a `chat-xdk-*` name is left untouched.
- Miss guard: stamping a lockfile with no workspace entries exits 1 with a clear error.
- `cargo check --locked` passes with the stamped lockfile.