### PR TITLE
fix(jvm): restore bundled natives in the Maven Central jar

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -549,8 +549,8 @@ jobs:
           find "$base" -type f
       - name: Package jar
         run: mvn -B -DskipTests -f crates/jvm/java/chatxdk/pom.xml package
-      # Guard against resource-configuration regressions: a jar published
-      # without the natives fails every consumer with UnsatisfiedLinkError.
+      # A jar without the natives fails every consumer with
+      # UnsatisfiedLinkError, so fail the release rather than publish one.
       - name: Verify jar bundles all platform natives
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -535,26 +535,40 @@ jobs:
         with:
           path: artifacts
           pattern: dotnet-native-*
-      # JNA extracts the library from the classpath at
-      # <Platform.RESOURCE_PREFIX>/<mapped name>, so bundling the cdylibs under
-      # these resource paths makes the jar self-contained.
-      - name: Stage natives into JNA resource paths (jar-bundled)
+      # NativeLoader extracts the bundled library from the classpath at
+      # native/<rid>/, so bundling the cdylibs under these resource paths
+      # makes the jar self-contained. The rids match the artifact names.
+      - name: Stage natives into NativeLoader resource paths (jar-bundled)
         run: |
           set -euo pipefail
-          base=crates/jvm/java/chatxdk/src/main/resources
-          declare -A prefix=(
-            [osx-arm64]=darwin-aarch64
-            [osx-x64]=darwin-x86-64
-            [linux-x64]=linux-x86-64
-            [win-x64]=win32-x86-64
-          )
-          for rid in "${!prefix[@]}"; do
-            mkdir -p "$base/${prefix[$rid]}"
-            cp artifacts/dotnet-native-"$rid"/* "$base/${prefix[$rid]}/"
+          base=crates/jvm/java/chatxdk/src/main/resources/native
+          for rid in osx-arm64 osx-x64 linux-x64 win-x64; do
+            mkdir -p "$base/$rid"
+            cp artifacts/dotnet-native-"$rid"/* "$base/$rid/"
           done
           find "$base" -type f
       - name: Package jar
         run: mvn -B -DskipTests -f crates/jvm/java/chatxdk/pom.xml package
+      # Guard against resource-configuration regressions: a jar published
+      # without the natives fails every consumer with UnsatisfiedLinkError.
+      - name: Verify jar bundles all platform natives
+        run: |
+          set -euo pipefail
+          jar="crates/jvm/java/chatxdk/target/chatxdk-${{ needs.prepare.outputs.version }}.jar"
+          contents="$(jar tf "$jar")"
+          for entry in \
+            native/osx-arm64/libchat_xdk_dotnet.dylib \
+            native/osx-x64/libchat_xdk_dotnet.dylib \
+            native/linux-x64/libchat_xdk_dotnet.so \
+            native/win-x64/chat_xdk_dotnet.dll \
+            META-INF/LICENSE \
+            META-INF/THIRD_PARTY_NOTICES.md; do
+            if ! grep -qx "$entry" <<<"$contents"; then
+              echo "::error::$jar is missing $entry — the jar would fail at runtime with UnsatisfiedLinkError. Check the pom <resources> configuration and the staging step."
+              exit 1
+            fi
+          done
+          echo "All platform natives present in $jar"
       - name: Publish to Maven Central (Central Portal)
         if: ${{ !inputs.dry_run }}
         env:

--- a/crates/jvm/java/chatxdk/pom.xml
+++ b/crates/jvm/java/chatxdk/pom.xml
@@ -58,10 +58,11 @@
   </dependencies>
 
   <build>
-    <!-- Declaring <resources> replaces Maven's default resource directory, so
-         src/main/resources must be re-declared explicitly: the release build
-         stages the per-platform chat_xdk_dotnet natives there (native/<rid>/)
-         and dropping it ships a jar without them. -->
+    <!-- An explicit <resources> block replaces Maven's default resource
+         directory rather than extending it, so src/main/resources must be
+         re-declared here: release builds stage the per-platform
+         chat_xdk_dotnet natives under src/main/resources/native/<rid>/, and
+         NativeLoader loads them from the jar at that path. -->
     <resources>
       <resource>
         <directory>src/main/resources</directory>

--- a/crates/jvm/java/chatxdk/pom.xml
+++ b/crates/jvm/java/chatxdk/pom.xml
@@ -58,8 +58,15 @@
   </dependencies>
 
   <build>
-    <!-- Ship project LICENSE + third-party notices inside the jar (META-INF/). -->
+    <!-- Declaring <resources> replaces Maven's default resource directory, so
+         src/main/resources must be re-declared explicitly: the release build
+         stages the per-platform chat_xdk_dotnet natives there (native/<rid>/)
+         and dropping it ships a jar without them. -->
     <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <!-- Ship project LICENSE + third-party notices inside the jar (META-INF/). -->
       <resource>
         <directory>${project.basedir}/../../../../</directory>
         <includes>


### PR DESCRIPTION
## Summary

Fixes #5 — `com.x:chatxdk:0.4.1` on Maven Central ships without the embedded `chat_xdk_dotnet` natives, so `new Chat()` fails with `UnsatisfiedLinkError` on every platform.

### Root cause

The pom's `<build><resources>` block (added to ship `LICENSE` / `THIRD_PARTY_NOTICES.md` into `META-INF`) **replaces** Maven's default `src/main/resources` directory rather than extending it. The release workflow stages the per-platform cdylibs into exactly that directory before `mvn package`, so they were silently dropped from the jar. Nothing caught it because CI and `make jvm-test` load the native via `-Djna.library.path`, never from the packaged jar.

### Changes

- **pom.xml**: re-declare `src/main/resources` alongside the META-INF resource, with a comment explaining the Maven replace-not-extend gotcha.
- **release.yml**: stage the natives at `native/<rid>/` — the layout `NativeLoader` documents and extracts — instead of JNA's `Platform.RESOURCE_PREFIX` layout, which only worked through the `Native.load` fallback. The rids match the artifact names, so the staging loop loses its mapping table.
- **release.yml**: add a post-package gate that fails the release if the versioned jar is missing any of the four platform natives or the META-INF legal files.

### Testing

- Packaged locally with a real staged darwin dylib: jar contains `native/osx-arm64/libchat_xdk_dotnet.dylib`, `META-INF/LICENSE`, `META-INF/THIRD_PARTY_NOTICES.md`.
- Full JVM suite (52 tests) passes **without** `-Djna.library.path`, forcing loading through `NativeLoader`'s classpath extraction.
- Reproduced the bug beforehand: the unpatched pom packages the same staged dylib into a jar with no natives.

### Follow-up

Publish 0.4.2 from the release workflow once this lands.