### PR TITLE
feat(js): make createChat's juiceboxConfig optional for first boot

### DIFF
--- a/crates/wasm/js/README.md
+++ b/crates/wasm/js/README.md
@@ -39,6 +39,24 @@ make wasm   # from the repo root; builds --target web and stages js/pkg/
 
 ## Quick Start
 
+First boot — the account's `juicebox_config` is created by
+`POST /2/users/:id/public_keys`, so a brand-new user has none yet. Create the
+chat without it, generate and POST the keys, then wire up Juicebox:
+
+```typescript
+import { createChat } from "@xdevplatform/chat-xdk";
+
+const chat = await createChat({
+  getAuthToken: async (realmId) => await myBackend.getToken(realmId),
+});
+const payload = chat.generateKeypairs();
+// … POST payload to /2/users/:id/public_keys, GET juicebox_config back …
+chat.updateConfig(configJson);
+await chat.setup("2580");
+```
+
+Later sessions pass the config up front and unlock:
+
 ```typescript
 import { createChat } from "@xdevplatform/chat-xdk";
 

--- a/crates/wasm/js/index.d.ts
+++ b/crates/wasm/js/index.d.ts
@@ -659,6 +659,13 @@ export interface CreateChatOptions {
    * Obtain this from the `juicebox_config` field of
    * GET /2/users/:id/public_keys (your own user, `public_key.fields=juicebox_config`).
    *
+   * Optional to support first boot: `juicebox_config` is created by
+   * POST /2/users/:id/public_keys, so a brand-new user has none yet. Omit
+   * it, call `generateKeypairs()` and POST the payload yourself, then call
+   * `updateConfig()` with the config returned by the GET and `setup(pin)`.
+   * Until a config is supplied, `setup`/`unlock`/`changePin`/`delete`
+   * throw; all crypto methods work.
+   *
    * Accepted shapes match the native bindings and are checked in this
    * order: the `sdk_config` wrapper (its embedded SDK config string is
    * unwrapped for the Juicebox client), the X API `juicebox_config` object
@@ -669,10 +676,13 @@ export interface CreateChatOptions {
    * them), or a raw realms config. Realm auth tokens always come from
    * `getAuthToken`, not the config.
    */
-  juiceboxConfig: string;
+  juiceboxConfig?: string;
   
   /**
    * Async function to get a Juicebox auth token for a realm.
+   *
+   * Required even when `juiceboxConfig` is omitted: the first Juicebox
+   * operation after `updateConfig()` (typically first-boot `setup`) needs it.
    * 
    * @param realmId - Hex-encoded realm ID
    * @returns Promise resolving to the auth token string
@@ -979,16 +989,26 @@ export declare class ChatWithJuicebox implements ChatCrypto {
    * Register keys with Juicebox. The PIN must meet strength requirements
    * (4+ characters, not a single repeated character or sequential digit
    * run). Pass a Uint8Array to be able to zero the buffer afterwards.
+   *
+   * Requires a Juicebox config: throws if the instance was created without
+   * `juiceboxConfig` and `updateConfig()` has not been called yet.
    */
   setup(pin: string | Uint8Array): Promise<PublicKeys>;
+  /** Requires a Juicebox config, like setup(). */
   unlock(pin: string | Uint8Array): Promise<void>;
+  /** Requires a Juicebox config, like setup(). */
   delete(): Promise<void>;
-  /** The new PIN must meet the same strength requirements as setup(). */
+  /**
+   * The new PIN must meet the same strength requirements as setup().
+   * Requires a Juicebox config, like setup().
+   */
   changePin(oldPin: string | Uint8Array, newPin: string | Uint8Array): Promise<void>;
   /**
-   * Re-create the Juicebox client from a new config (e.g. refreshed auth
+   * (Re-)create the Juicebox client from a config (e.g. refreshed auth
    * tokens) and re-resolve the PIN guess budget from it; an explicit
-   * createChat `maxGuessCount` override keeps winning.
+   * createChat `maxGuessCount` override keeps winning. On an instance
+   * created without `juiceboxConfig`, this is the first-boot step that
+   * enables `setup`/`unlock`/`changePin`/`delete`.
    */
   updateConfig(juiceboxConfig: string): void;
 
@@ -1037,6 +1057,10 @@ export declare class ChatWithJuicebox implements ChatCrypto {
 
 /**
  * Create a Chat instance with integrated Juicebox key storage.
+ *
+ * `juiceboxConfig` is optional: on first boot (no `juicebox_config` on the
+ * account yet) create with just `getAuthToken`, `generateKeypairs()`, POST
+ * the payload, then `updateConfig()` + `setup(pin)`.
  *
  * Each call creates an independent instance with its own Juicebox client.
  * The Juicebox auth-token callback is a process-wide global that each

--- a/crates/wasm/js/index.js
+++ b/crates/wasm/js/index.js
@@ -263,6 +263,10 @@ export function juiceboxClientConfig(configValue) {
 export class ChatWithJuicebox {
   /** @type {import('./pkg/chat_xdk_wasm.js').Chat} */
   #inner;
+  // Null until a Juicebox config is supplied (createChat or updateConfig):
+  // a first-boot instance has no config yet because the account's
+  // juicebox_config is only created by the public-key POST. Crypto methods
+  // never touch it; the Juicebox lifecycle methods refuse while it is null.
   #juiceboxClient;
   #numGuesses;
   // The raw `maxGuessCount` createChat option (undefined when not provided),
@@ -297,19 +301,38 @@ export class ChatWithJuicebox {
   // Juicebox lifecycle (handled in this JS layer)
 
   /**
+   * Every Juicebox operation needs a client, which exists only once a config
+   * has been supplied (to createChat or updateConfig). A first-boot instance
+   * created without one gets a deliberate error here instead of a TypeError
+   * from calling register/recover/delete on null.
+   */
+  #requireJuiceboxClient() {
+    if (!this.#juiceboxClient) {
+      throw new Error(
+        "No Juicebox config: pass juiceboxConfig to createChat() or call " +
+          "updateConfig() with the juicebox_config from the X API before " +
+          "setup/unlock/changePin/delete.",
+      );
+    }
+    return this.#juiceboxClient;
+  }
+
+  /**
    * Register existing keys with Juicebox. Call generateKeypairs() first.
    * The PIN must meet minimum strength requirements (4+ characters, not a
    * single repeated character or a sequential digit run). Accepts a string
    * or a Uint8Array; pass a Uint8Array if you want to zero it afterwards.
+   * Requires a Juicebox config (from createChat or updateConfig).
    */
   async setup(pin) {
+    const client = this.#requireJuiceboxClient();
     const pinBytes = toPinBytes(pin);
     const ownsPin = typeof pin === 'string';
     validatePinStrength(pinBytes);
     const secretBytes = this.#inner.exportKeys();
     try {
       this.#armAuthTokenHook();
-      await this.#juiceboxClient.register(
+      await client.register(
         pinBytes,
         secretBytes,
         new Uint8Array(0),
@@ -327,14 +350,16 @@ export class ChatWithJuicebox {
   /**
    * Unlock: Recover keys from Juicebox using PIN (string or Uint8Array).
    * No strength validation — existing registrations must stay recoverable.
+   * Requires a Juicebox config (from createChat or updateConfig).
    */
   async unlock(pin) {
+    const client = this.#requireJuiceboxClient();
     const pinBytes = toPinBytes(pin);
     const ownsPin = typeof pin === 'string';
     let secretBytes;
     try {
       this.#armAuthTokenHook();
-      secretBytes = await this.#juiceboxClient.recover(pinBytes, new Uint8Array(0));
+      secretBytes = await client.recover(pinBytes, new Uint8Array(0));
     } catch (err) {
       throw new Error(`Juicebox recovery failed: ${formatJuiceboxError(err, RECOVER_REASON_BY_VALUE)}`);
     } finally {
@@ -347,15 +372,23 @@ export class ChatWithJuicebox {
     }
   }
 
-  /** Delete keys from Juicebox. Warning: Irreversible. */
+  /**
+   * Delete keys from Juicebox. Warning: Irreversible.
+   * Requires a Juicebox config (from createChat or updateConfig).
+   */
   async delete() {
+    const client = this.#requireJuiceboxClient();
     this.#armAuthTokenHook();
-    await this.#juiceboxClient.delete();
+    await client.delete();
     this.#inner.lock();
   }
 
-  /** Re-register keys with a new PIN. The new PIN must meet strength requirements. */
+  /**
+   * Re-register keys with a new PIN. The new PIN must meet strength
+   * requirements. Requires a Juicebox config (from createChat or updateConfig).
+   */
   async changePin(oldPin, newPin) {
+    const client = this.#requireJuiceboxClient();
     const newPinBytes = toPinBytes(newPin);
     const ownsNewPin = typeof newPin === 'string';
     validatePinStrength(newPinBytes);
@@ -363,7 +396,7 @@ export class ChatWithJuicebox {
     const secretBytes = this.#inner.exportKeys();
     try {
       this.#armAuthTokenHook();
-      await this.#juiceboxClient.register(
+      await client.register(
         newPinBytes,
         secretBytes,
         new Uint8Array(0),
@@ -378,9 +411,12 @@ export class ChatWithJuicebox {
   }
 
   /**
-   * Update Juicebox config (e.g. to refresh auth tokens). Re-creates the
+   * Update Juicebox config (e.g. to refresh auth tokens). (Re-)creates the
    * client and re-resolves the PIN guess budget from the new config; an
-   * explicit createChat `maxGuessCount` override keeps winning.
+   * explicit createChat `maxGuessCount` override keeps winning. On an
+   * instance created without a config, this is what enables
+   * setup/unlock/changePin/delete — first boot calls it with the
+   * `juicebox_config` created by the public-key POST, then `setup(pin)`.
    */
   updateConfig(juiceboxConfig) {
     const configValue = JSON.parse(juiceboxConfig);
@@ -447,7 +483,12 @@ export class ChatWithJuicebox {
  * Create a Chat instance with integrated Juicebox support.
  * 
  * @param {Object} options - Configuration options
- * @param {string} options.juiceboxConfig - Juicebox configuration JSON from X API
+ * @param {string} [options.juiceboxConfig] - Juicebox configuration JSON from
+ *                                            the X API. Omit on first boot —
+ *                                            before the first public-key POST
+ *                                            the account has no
+ *                                            juicebox_config; supply it later
+ *                                            via updateConfig()
  * @param {Function} options.getAuthToken - Async function to get auth token for a realm
  *                                          Signature: (realmId: string) => Promise<string>
  * @param {number} [options.maxGuessCount] - Optional override for the PIN guess
@@ -455,6 +496,15 @@ export class ChatWithJuicebox {
  * @returns {Promise<ChatWithJuicebox>} Initialized chat instance
  * 
  * @example
+ * // First boot — the account has no juicebox_config yet
+ * const chat = await createChat({ getAuthToken });
+ * const payload = chat.generateKeypairs();
+ * // POST payload to /2/users/:id/public_keys (this creates juicebox_config),
+ * // then GET it back and store the keys under a PIN:
+ * chat.updateConfig(configFromXApi);
+ * await chat.setup("2580");
+ * 
+ * // Subsequent sessions — the account is provisioned
  * const chat = await createChat({
  *   juiceboxConfig: configFromXApi,
  *   getAuthToken: async (realmId) => {
@@ -462,21 +512,11 @@ export class ChatWithJuicebox {
  *     return response.text();
  *   },
  * });
- * 
- * // First time setup
- * const payload = chat.generateKeypairs();
- * // POST payload to X API, then call setup once you have juiceboxConfig
- * await chat.setup("2580");
- * 
- * // Subsequent sessions
  * await chat.unlock("2580");
  */
 export async function createChat(options) {
   const { juiceboxConfig, getAuthToken, maxGuessCount } = options;
 
-  if (!juiceboxConfig) {
-    throw new Error('juiceboxConfig is required');
-  }
   if (!getAuthToken || typeof getAuthToken !== 'function') {
     throw new Error('getAuthToken must be an async function');
   }
@@ -528,11 +568,20 @@ export async function createChat(options) {
   };
   armAuthTokenHook();
 
-  const configValue = JSON.parse(juiceboxConfig);
-  const config = new JuiceboxConfiguration(juiceboxClientConfig(configValue));
-  const juiceboxClient = new JuiceboxClientCtor(config, []);
-
-  const numGuesses = resolveMaxGuessCount(configValue, maxGuessCount);
+  // First boot has no config yet (the account's juicebox_config is created
+  // by the public-key POST), so no Juicebox Configuration/Client is built;
+  // updateConfig() constructs them once the real config exists. Crypto
+  // methods and generateKeypairs need neither. Only an absent config means
+  // first boot — a present-but-empty value is a caller bug and fails to
+  // parse here rather than surfacing later as a missing-config error.
+  let juiceboxClient = null;
+  let numGuesses;
+  if (juiceboxConfig != null) {
+    const configValue = JSON.parse(juiceboxConfig);
+    const config = new JuiceboxConfiguration(juiceboxClientConfig(configValue));
+    juiceboxClient = new JuiceboxClientCtor(config, []);
+    numGuesses = resolveMaxGuessCount(configValue, maxGuessCount);
+  }
 
   // Load Rust WASM crypto engine
   const wasmModule = await initWasmModule();

--- a/crates/wasm/js/tests/wrapper.test.mjs
+++ b/crates/wasm/js/tests/wrapper.test.mjs
@@ -30,8 +30,11 @@ function b64ToBytes(b64) {
 
 // Network-backend stubs (Juicebox realm I/O lives outside the SDK).
 class StubJuiceboxConfiguration {
+  static instances = [];
+
   constructor(value) {
     this.value = value;
+    StubJuiceboxConfiguration.instances.push(this);
   }
 }
 
@@ -517,9 +520,92 @@ async function guessBudgetTests() {
   });
 }
 
+// First boot: the account's juicebox_config is created by the public-key
+// POST, so createChat must work without one — crypto (including
+// generateKeypairs) available immediately, Juicebox lifecycle gated until
+// updateConfig supplies the real config.
+async function firstBootTests() {
+  const clientsBefore = StubJuiceboxClient.instances.length;
+  const configsBefore = StubJuiceboxConfiguration.instances.length;
+  const chat = await createChat({
+    getAuthToken: async () => "stub-token",
+    juiceboxModule,
+  });
+  // No config ⇒ no Juicebox Configuration/Client is constructed.
+  assert.equal(StubJuiceboxClient.instances.length, clientsBefore);
+  assert.equal(StubJuiceboxConfiguration.instances.length, configsBefore);
+
+  // Crypto works before any config: generateKeypairs yields a full
+  // registration payload the caller can POST.
+  const payload = chat.generateKeypairs();
+  assert.ok(payload.publicKey.publicKey.length > 0);
+  assert.ok(payload.publicKey.signingPublicKey.length > 0);
+  assert.equal(chat.isUnlocked(), true);
+
+  // Juicebox lifecycle before any config fails with the deliberate error —
+  // not a constructor crash — and never reaches a client.
+  for (const op of [
+    () => chat.setup("2580"),
+    () => chat.unlock("2580"),
+    () => chat.changePin("2580", "1359"),
+    () => chat.delete(),
+  ]) {
+    await assert.rejects(op, /No Juicebox config/);
+  }
+  assert.equal(StubJuiceboxClient.instances.length, clientsBefore);
+
+  // updateConfig with the real (post-POST) config enables setup: exactly one
+  // register call, on the client built from that config.
+  chat.updateConfig(JSON.stringify({ realms: [], max_guess_count: 6 }));
+  assert.equal(StubJuiceboxClient.instances.length, clientsBefore + 1);
+  const client = lastClient();
+  assert.equal(client.registerCalls, 0);
+  const keys = await chat.setup("2580");
+  assert.equal(client.registerCalls, 1);
+  assert.equal(client.lastNumGuesses, 6);
+  assert.equal(keys.identity, chat.getPublicKeys().identity);
+
+  // The stored identity round-trips through unlock on the same instance.
+  chat.lock();
+  await chat.unlock("2580");
+  assert.equal(chat.isUnlocked(), true);
+  assert.equal(chat.getPublicKeys().identity, keys.identity);
+
+  // An explicit createChat maxGuessCount override survives a config-less
+  // construction and still beats the config supplied later by updateConfig.
+  const pinned = await createChat({
+    getAuthToken: async () => "stub-token",
+    juiceboxModule,
+    maxGuessCount: 9,
+  });
+  pinned.updateConfig(JSON.stringify({ realms: [], max_guess_count: 3 }));
+  pinned.generateKeypairs();
+  await pinned.setup("2580");
+  assert.equal(lastClient().lastNumGuesses, 9);
+
+  // A present-but-empty config is a caller bug, not first boot: it fails at
+  // createChat rather than deferring to a missing-config error at setup.
+  await assert.rejects(
+    () =>
+      createChat({
+        juiceboxConfig: "",
+        getAuthToken: async () => "stub-token",
+        juiceboxModule,
+      }),
+    SyntaxError,
+  );
+
+  // getAuthToken stays mandatory even when the config is omitted.
+  await assert.rejects(
+    () => createChat({ juiceboxModule }),
+    /getAuthToken must be an async function/,
+  );
+}
+
 async function main() {
   await delegationTests();
   await guessBudgetTests();
+  await firstBootTests();
   console.log("wrapper.test.mjs: all assertions passed");
 }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -16,7 +16,7 @@ The JVM binding mirrors the .NET surface (JSON across the native boundary, same 
 
 | # | Method | Rust | JS | Python | Go | JVM | .NET |
 |---|--------|------|-----|--------|-----|------|------|
-| 1 | **new** | `Chat::new(config: JuiceboxConfig)` | `new Chat()` (config via `createChat(opts)`) | `Chat(config_json?: str)` | `New() *Chat` (free with `Close()`) | `new Chat()` (free with `close()` / `try-with-resources`) | `new Chat()` then `UpdateConfig(string)` (free with `Dispose()` / `using`) |
+| 1 | **new** | `Chat::new(config: JuiceboxConfig)` | `new Chat()` (config via `createChat(opts)`; `juiceboxConfig` optional) | `Chat(config_json?: str)` | `New() *Chat` (free with `Close()`) | `new Chat()` (free with `close()` / `try-with-resources`) | `new Chat()` then `UpdateConfig(string)` (free with `Dispose()` / `using`) |
 | 2 | **update_config** | `update_config(&mut self, config)` | `updateConfig(config: string)` | `update_config(config_json: str)` | `UpdateConfig(configJSON string) error` | `updateConfig(String)` | `UpdateConfig(string)` |
 | 3 | **set_reject_unverified** | `set_reject_unverified(&mut self, reject: bool)` | `setRejectUnverified(reject: boolean)` | `set_reject_unverified(reject: bool)` | `SetRejectUnverified(reject bool)` | `setRejectUnverified(boolean)` | `SetRejectUnverified(bool)` |
 
@@ -43,6 +43,16 @@ In JS, realm auth tokens always come from the `getAuthToken` callback
 instead of the config, so the `tokens`/`token_map` token fields are not
 validated there (and a raw realms config is accepted as a fourth shape);
 a config accepted by JS may still be rejected by the native bindings.
+
+`createChat`'s `juiceboxConfig` is optional to support **JS first boot**: the
+account's `juicebox_config` is created by `POST /2/users/:id/public_keys`, so
+a brand-new user has none yet. Created without a config, the instance runs
+every crypto method (including `generateKeypairs`) but builds no Juicebox
+client; `setup`/`unlock`/`changePin`/`delete` throw a clear error until
+`updateConfig` supplies a real config. The first-boot flow is:
+`createChat({ getAuthToken })` → `generateKeypairs()` → caller POSTs the
+payload → `updateConfig(configFromGet)` → `setup(pin)`. Already-provisioned
+accounts keep passing `juiceboxConfig` at creation, unchanged.
 
 ### Juicebox Key Storage
 
@@ -953,6 +963,23 @@ ImageDimensions? dims = ChatXdkUtilities.DetectImageDimensions(imageBytes);
 ## Quick Start
 
 ### JavaScript/WASM
+
+First boot — `juicebox_config` is created by `POST /2/users/:id/public_keys`,
+so a brand-new user creates the chat without one:
+
+```typescript
+import { createChat } from '@xdevplatform/chat-xdk';
+
+const chat = await createChat({
+  getAuthToken: async (realmId) => await backend.getToken(realmId),
+});
+const payload = chat.generateKeypairs();
+// … POST payload to /2/users/:id/public_keys, GET juicebox_config back …
+chat.updateConfig(configJson);
+await chat.setup("2580");
+```
+
+Later sessions — the account is provisioned:
 
 ```typescript
 import { createChat } from '@xdevplatform/chat-xdk';

--- a/examples/js/README.md
+++ b/examples/js/README.md
@@ -81,13 +81,15 @@ X_ACCESS_TOKEN=... CHAT_PIN=... npm run register -- --confirm
 The browser-safe WASM binding has no key export, so — unlike the other
 language examples — this persists the identity in **Juicebox** under `CHAT_PIN`
 (required) instead of a local blob; the bot then recovers it with `unlock(pin)`.
-It needs the optional `juicebox-sdk` peer dependency installed, and the account
-must already have a Juicebox realm config — if it does not, register the first
-identity with a native binding (which stores a local key blob). Before POSTing,
-it checks whether the key is already on the account and skips the write if so;
-on HTTP 429 it stops and prints when the window resets rather than retrying. A
-marker under `state/` records that registration is done (`--force` overrides to
-mint a new identity). `state/` is gitignored — never commit key material.
+It needs the optional `juicebox-sdk` peer dependency installed. A brand-new
+account works too: the account's `juicebox_config` is created by the
+public-key POST itself, so the script creates the chat with no config,
+generates keys, POSTs the public key, then fetches the config and stores the
+keys with `updateConfig` + `setup(pin)`. Before POSTing, it checks whether the
+key is already on the account and skips the write if so; on HTTP 429 it stops
+and prints when the window resets rather than retrying. A marker under
+`state/` records that registration is done (`--force` overrides to mint a new
+identity). `state/` is gitignored — never commit key material.
 
 ## Key generation in the browser
 

--- a/examples/js/src/register.mjs
+++ b/examples/js/src/register.mjs
@@ -8,18 +8,23 @@
  * JS-specific difference from the other bindings: the browser-safe WASM
  * binding deliberately exposes NO exportKeys/importKeys, so there is no
  * private-key blob to write to disk. Juicebox IS the durable store here, so a
- * PIN is required. The identity is made durable BEFORE the network call:
- * generate, `setup(pin)` (store in Juicebox), record the marker — then POST.
- * An interrupted run is resumed by recovering the same identity with
- * `unlock(pin)` and re-sending the saved registration body, so it never mints
- * a new identity or wastes the strict daily budget. Safety properties:
+ * PIN is required. The account's `juicebox_config` is created BY the
+ * public-key POST, so a brand-new user necessarily runs first boot in this
+ * order: create the chat with no config, generate keys, POST the public key,
+ * fetch the now-existing `juicebox_config`, then `updateConfig` + `setup(pin)`
+ * to make the identity durable. Safety properties:
  *   1. the one-time marker (state/registration.json) — refuse to re-register;
- *   2. resume via unlock(pin) — a run interrupted after setup recovers the same
- *      identity instead of generating a new one;
+ *   2. the marker (with the public POST body) is written only after a
+ *      successful setup(pin), so a marker body always denotes an identity that
+ *      is recoverable from Juicebox via unlock(pin) — a run that finds a body
+ *      without registered:true recovers that identity and re-sends the saved
+ *      body instead of minting a new one;
  *   3. reconcile-before-POST — if our exact public key is already on the
  *      account (a prior POST can apply server-side even after erroring), adopt
  *      it and skip the POST.
- * Stop cleanly on HTTP 429 rather than retrying.
+ * Stop cleanly on HTTP 429 rather than retrying. A 429 on a freshly minted
+ * identity discards it — nothing durable was stored and the failed POST
+ * consumed no budget — so the re-run simply mints a new one.
  *
  * Environment (see .env.example):
  *   X_ACCESS_TOKEN     OAuth2 user token for the bot (dm.read + dm.write)
@@ -66,18 +71,52 @@ async function writeMarker(marker) {
 }
 
 /**
- * Build the per-realm auth-token callback createChat needs. Realm tokens live
- * in the `token_map` of the X API `juicebox_config`, keyed by hex realm id.
+ * Realm auth tokens live in the `token_map` of the X API `juicebox_config`,
+ * which does not exist until the first public-key POST. The getter handed to
+ * createChat therefore reads a mutable map, (re)filled from whichever config
+ * is fetched later in the run.
  */
-function authTokenGetter(configJson) {
+const realmTokens = new Map();
+
+function loadRealmTokens(configJson) {
   const parsed = JSON.parse(configJson);
-  const tokens = new Map();
+  realmTokens.clear();
   for (const entry of parsed.token_map ?? parsed.tokenMap ?? []) {
     const realm = String(entry?.key ?? "").toLowerCase();
     const token = entry?.value?.token;
-    if (realm && typeof token === "string") tokens.set(realm, token);
+    if (realm && typeof token === "string") realmTokens.set(realm, token);
   }
-  return async (realmId) => tokens.get(String(realmId).toLowerCase()) ?? "";
+}
+
+const getAuthToken = async (realmId) => realmTokens.get(String(realmId).toLowerCase()) ?? "";
+
+/**
+ * The PIN rules setup() enforces, checked before any budget is spent:
+ * setup() can only run after the public-key POST (the config it needs is
+ * created by that POST), so a PIN it would reject must fail the run before
+ * the POST rather than strand a freshly registered key. Returns the reason
+ * the PIN is unacceptable, or null when it is fine.
+ */
+function weakPinReason(pin) {
+  const bytes = new TextEncoder().encode(pin);
+  if (bytes.length < 4) return "must be at least 4 characters";
+  if (bytes.every((b) => b === bytes[0])) return "must not be a single repeated character";
+  const allDigits = bytes.every((b) => b >= 0x30 && b <= 0x39);
+  let ascending = true;
+  let descending = true;
+  for (let i = 1; i < bytes.length; i++) {
+    if (bytes[i] !== bytes[i - 1] + 1) ascending = false;
+    if (bytes[i] !== bytes[i - 1] - 1) descending = false;
+  }
+  if (allDigits && (ascending || descending)) return "must not be a sequential run of digits";
+  return null;
+}
+
+/** Fetch juicebox_config, feed its realm tokens to getAuthToken, and arm the chat with it. */
+async function applyJuiceboxConfig(api, chat, userId) {
+  const { configJson } = await api.getJuiceboxConfig(userId);
+  loadRealmTokens(configJson);
+  chat.updateConfig(configJson);
 }
 
 async function register({ force }) {
@@ -107,24 +146,34 @@ async function register({ force }) {
   const api = new XChatClient(token);
   const userId = process.env.CHAT_BOT_USER_ID || (await api.getMyUserId());
 
-  // Juicebox config is needed up front (before generating keys) because it is
-  // the only place the identity can be persisted in this binding.
-  const { configJson } = await api.getJuiceboxConfig(userId);
-  const chat = await createChat({ juiceboxConfig: configJson, getAuthToken: authTokenGetter(configJson) });
+  // No juicebox_config yet on first boot (the POST below creates it), so the
+  // chat is created without one; crypto and generateKeypairs work regardless.
+  const chat = await createChat({ getAuthToken });
 
-  // Resume an interrupted run with the SAME identity: recover it from Juicebox
-  // and reuse the saved registration body. Only generate + store a fresh
-  // identity when there is no in-progress one. Storing in Juicebox and
-  // recording the body BEFORE the POST is what makes a failed POST safe to
-  // retry without minting a new identity or wasting the daily budget.
+  // A marker body without registered:true denotes an identity whose
+  // setup(pin) succeeded but whose registration was never confirmed complete:
+  // it is durable in Juicebox and juicebox_config exists. Recover that SAME
+  // identity and re-send the saved registration body instead of minting a new
+  // one (which would waste the strict daily budget). Without a saved body
+  // there is nothing to resume — mint a fresh identity.
   let body;
   let version;
+  let minted = false;
   if (marker.body && !force) {
+    await applyJuiceboxConfig(api, chat, userId);
     await chat.unlock(pin);
     body = marker.body;
     version = String(marker.version ?? "1");
     console.log("Resuming the saved identity (recovered from Juicebox).");
   } else {
+    const weak = weakPinReason(pin);
+    if (weak) {
+      console.error(
+        `CHAT_PIN ${weak}. setup(pin) would reject it after the rate-limited ` +
+          "POST and strand the new key — pick a stronger PIN and re-run.",
+      );
+      process.exit(1);
+    }
     const reg = chat.generateKeypairs();
     version = String(reg.version ?? "1");
     // Snake_case wire form — the exact body the X API public-key endpoint takes.
@@ -139,9 +188,8 @@ async function register({ force }) {
       version,
       generate_version: Boolean(reg.generateVersion),
     };
-    await chat.setup(pin); // durable store BEFORE the POST
-    await writeMarker({ registered: false, user_id: userId, version, body });
-    console.log("Generated a new identity; stored in Juicebox under your PIN.");
+    minted = true;
+    console.log("Generated a new identity.");
   }
   const ourPublicKey = body.public_key.public_key;
 
@@ -166,12 +214,50 @@ async function register({ force }) {
           : "the next window";
         console.error(
           "Registration is rate limited (429). The daily budget is exhausted; " +
-            `wait until ${when} and re-run — the saved identity resumes, so no budget is wasted.`,
+            `wait until ${when} and re-run. ` +
+            (minted
+              ? "The just-minted identity is discarded (nothing durable was stored " +
+                "and the failed POST consumed no budget); the re-run mints a new one."
+              : "The saved identity resumes, so no budget is wasted."),
         );
         process.exit(1);
       }
       throw err;
     }
+  }
+
+  // First boot only: the POST above created juicebox_config, so the identity
+  // can now be made durable. The private key exists only in this process
+  // until setup() stores it, so a transient failure fetching the just-created
+  // config or reaching the realms is retried before declaring the freshly
+  // registered key lost. The marker is written only after setup succeeds — it
+  // must never point at an identity that cannot be recovered via unlock.
+  if (minted) {
+    let stored = false;
+    let lastErr;
+    for (let attempt = 1; attempt <= 3 && !stored; attempt++) {
+      try {
+        if (attempt > 1) {
+          console.log(`Storing keys in Juicebox failed; retrying (attempt ${attempt}/3) …`);
+          await new Promise((resolve) => setTimeout(resolve, 2000 * attempt));
+        }
+        await applyJuiceboxConfig(api, chat, userId);
+        await chat.setup(pin);
+        stored = true;
+      } catch (err) {
+        lastErr = err;
+      }
+    }
+    if (!stored) {
+      console.error(
+        `Storing the keys in Juicebox failed AFTER public key version ${version} was ` +
+          "registered on the account. This binding has no key export, so that key is " +
+          "now unusable; re-run with --force to mint and register a replacement " +
+          "(this consumes registration budget).",
+      );
+      throw lastErr;
+    }
+    console.log("Keys stored in Juicebox under your PIN.");
   }
 
   // Records the registered key version and the session identity in one call.
@@ -181,6 +267,7 @@ async function register({ force }) {
     registered: true,
     user_id: userId,
     version,
+    body,
     registered_at: new Date().toISOString(),
   });
 

--- a/examples/js/src/x-api.mjs
+++ b/examples/js/src/x-api.mjs
@@ -96,11 +96,11 @@ export class XChatClient {
     const config = latest.juiceboxConfig ?? latest.juicebox_config;
     if (!config) {
       throw new Error(
-        "no juicebox_config on the account. The browser-safe binding stores keys " +
-          "only in Juicebox, so it needs the account's realm config to register. " +
-          "Register the first identity with a native binding (which persists a key " +
-          "blob), or use an already-provisioned account (juicebox_config is always " +
-          "returned once provisioned).",
+        "no juicebox_config on the account yet. It is created by " +
+          "POST /2/users/:id/public_keys, so register a public key first — " +
+          "src/register.mjs does this: createChat with no config, " +
+          "generateKeypairs, POST, then updateConfig + setup(pin). Once " +
+          "provisioned, juicebox_config is always returned.",
       );
     }
     // Passed to the SDK as-is: it reads `key_store_token_map_json` verbatim.


### PR DESCRIPTION
## Problem

`juicebox_config` is created by `POST /2/users/:id/public_keys`, but the JS binding's only entry point was `createChat({ juiceboxConfig, getAuthToken })` with `juiceboxConfig` required. A brand-new user therefore could not construct a chat instance at all, and callers (including the X Developer Console) worked around it by passing a fake Juicebox realm (`example.invalid`) just to get an instance, then swapping in the real config. The official JS example documented the hole by telling users to register their first identity with a native binding.

The JS binding deliberately exposes no `exportKeys`/`importKeys` (private material stays inside the WASM boundary; Juicebox is the durable store), so this could not be fixed by persisting a key blob.

## Change

`createChat({ getAuthToken })` now constructs without a config:

- No Juicebox `Configuration`/`Client` is built when the config is omitted; `updateConfig()` constructs them once the real config exists.
- Every crypto method — including `generateKeypairs()` — works immediately.
- `setup`/`unlock`/`changePin`/`delete` throw a clear `No Juicebox config: pass juiceboxConfig to createChat() or call updateConfig() …` error instead of a `TypeError` on a null client.
- First boot is: `createChat({ getAuthToken })` → `generateKeypairs()` → **caller** POSTs the payload to `/2/users/:id/public_keys` → `updateConfig(configFromGet)` → `setup(pin)`.
- Provisioned accounts passing `juiceboxConfig` at creation are unchanged. `getAuthToken` stays required (setup needs it even when the config arrives later), and a present-but-empty config still fails at `createChat` time rather than surfacing later as a missing-config error.
- No raw key export was added; the POST helper stays in `examples/` (the SDK's crypto-only boundary is unchanged — no networking in `crates/`).

## Example

`examples/js/src/register.mjs` now registers a brand-new user end to end: create with no config → generate → reconcile/POST the public key → fetch the config that POST just created → `updateConfig` + `setup(pin)`. It validates the PIN **before** the rate-limited POST (a PIN `setup` would reject must not strand a freshly registered key), retries the config fetch + Juicebox store before declaring a registered key lost, and writes the resume marker only after a successful `setup` so a saved body always denotes an identity recoverable via `unlock(pin)`. The "register the first identity with a native binding" instructions are gone from the example and from `getJuiceboxConfig`'s error text.

## Tests

New `firstBootTests()` in `crates/wasm/js/tests/wrapper.test.mjs` drives the real wrapper over the real WASM engine, stubbing only the Juicebox network client (the existing pattern):

1. `createChat({ getAuthToken, juiceboxModule })` with no config succeeds, constructing zero Juicebox `Configuration`/`Client` instances.
2. `generateKeypairs()` returns a full registration payload with no `register` call.
3. `setup`/`unlock`/`changePin`/`delete` before `updateConfig` reject with `/No Juicebox config/`.
4. `updateConfig(realConfig)` then `setup(pin)` calls the stub `register` exactly once with the config's guess budget, and the identity round-trips through `unlock`.
5. All pre-existing config-at-creation suites pass unchanged; plus: the `maxGuessCount` override survives config-less construction, an empty-string config fails at `createChat`, and `getAuthToken` stays mandatory.

Verified the suite fails if the old `juiceboxConfig is required` throw is reintroduced.

- `make ci` (fmt-check, clippy `-D warnings`, workspace tests) — passes
- `node crates/wasm/js/tests/{wrapper,api,sdk_vectors}.test.mjs` — pass
- `tsc --noEmit` on `index.d.ts` — clean

## Not changed

Wire formats, Juicebox `UserInfo`, native `Chat` constructors, and the other bindings (Python/Go/Rust/.NET/JVM already construct without a config, so no parity gap). Docs (`docs/API.md`, both READMEs, `index.d.ts`) updated in lockstep.
