### PR TITLE
feat(ci): build the linux-arm64 native for the .NET and JVM bindings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -429,6 +429,10 @@ jobs:
             rust_target: x86_64-unknown-linux-gnu
             rid: linux-x64
             lib: libchat_xdk_dotnet.so
+          - runs_on: ubuntu-24.04-arm
+            rust_target: aarch64-unknown-linux-gnu
+            rid: linux-arm64
+            lib: libchat_xdk_dotnet.so
           - runs_on: windows-latest
             rust_target: x86_64-pc-windows-msvc
             rid: win-x64
@@ -489,7 +493,7 @@ jobs:
         run: |
           set -euo pipefail
           base=crates/dotnet/dotnet/ChatXdk/runtimes
-          for rid in osx-arm64 osx-x64 linux-x64 win-x64; do
+          for rid in osx-arm64 osx-x64 linux-x64 linux-arm64 win-x64; do
             mkdir -p "$base/$rid/native"
             cp artifacts/dotnet-native-$rid/* "$base/$rid/native/"
           done
@@ -542,7 +546,7 @@ jobs:
         run: |
           set -euo pipefail
           base=crates/jvm/java/chatxdk/src/main/resources/native
-          for rid in osx-arm64 osx-x64 linux-x64 win-x64; do
+          for rid in osx-arm64 osx-x64 linux-x64 linux-arm64 win-x64; do
             mkdir -p "$base/$rid"
             cp artifacts/dotnet-native-"$rid"/* "$base/$rid/"
           done
@@ -560,6 +564,7 @@ jobs:
             native/osx-arm64/libchat_xdk_dotnet.dylib \
             native/osx-x64/libchat_xdk_dotnet.dylib \
             native/linux-x64/libchat_xdk_dotnet.so \
+            native/linux-arm64/libchat_xdk_dotnet.so \
             native/win-x64/chat_xdk_dotnet.dll \
             META-INF/LICENSE \
             META-INF/THIRD_PARTY_NOTICES.md; do

--- a/crates/jvm/java/chatxdk/src/main/java/com/x/chatxdk/NativeLoader.java
+++ b/crates/jvm/java/chatxdk/src/main/java/com/x/chatxdk/NativeLoader.java
@@ -61,7 +61,7 @@ final class NativeLoader {
         return out;
     }
 
-    /** RID labels aligned with the .NET / CI matrix: osx-arm64, osx-x64, linux-x64, win-x64. */
+    /** RID labels aligned with the .NET / CI matrix: osx-arm64, osx-x64, linux-x64, linux-arm64, win-x64. */
     static String detectRid() {
         String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
         String arch = System.getProperty("os.arch", "").toLowerCase(Locale.ROOT);
@@ -76,6 +76,9 @@ final class NativeLoader {
                 return "osx-x64";
             }
         } else if (os.contains("linux")) {
+            if (arm) {
+                return "linux-arm64";
+            }
             if (x64) {
                 return "linux-x64";
             }


### PR DESCRIPTION
Closes #16.

## Problem

The `chat_xdk_dotnet` cdylib ships for `osx-arm64`, `osx-x64`, `linux-x64` and `win-x64`. There is no `linux-arm64`, so the JVM and .NET bindings cannot run on 64-bit ARM Linux — AWS Graviton, Ampere, and ARM CI runners.

On Linux/aarch64, `detectRid()` returns `null`, so `extractBundledLibrary()` extracts nothing and `load()` falls through to a system lookup that finds nothing unless the operator supplies their own build.

Because `dotnet-build` also feeds the `java` job, this single missing matrix entry affects both bindings.

## Change

- one `linux-arm64` entry in the `dotnet-build` matrix, on `ubuntu-24.04-arm` targeting `aarch64-unknown-linux-gnu`
- `linux-arm64` staged alongside the other RIDs for both the nupkg and the jar
- `native/linux-arm64/libchat_xdk_dotnet.so` added to the jar verification list, so a missing artifact fails the release rather than shipping silently
- `detectRid()` returns `linux-arm64` on Linux/ARM

The `ubuntu-24.04-arm` runner and the `aarch64-unknown-linux-gnu` target are already used by the Python wheel job in this same workflow, so nothing new is introduced to CI.

## Verification

Built `chat-xdk-dotnet` for `aarch64-unknown-linux-gnu` from v0.5.0, with `juicebox-sdk` as a sibling checkout and the pinned 1.91.1 toolchain:

```
Finished `release` profile [optimized] target(s) in 1m 25s
libchat_xdk_dotnet.so: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked
```

Loaded through JNA on an ARM64 JVM (Temurin 25), with no `jna.library.path` set, to confirm the resource path `detectRid()` now returns is the one JNA resolves:

```
arch=aarch64
RESOURCE_PREFIX=linux-aarch64
LOADED OK: true
```

I have not been able to run the full release workflow, so the matrix entry itself is unexercised — the build and load above were reproduced locally against the same source and toolchain.

## Note

I have not signed the CLA. My employer likely holds rights to this work, so the authority representation in section 4 needs an internal check before I can sign. Happy to sort that out if you want to take the PR — otherwise please feel free to apply the diff directly and close this.